### PR TITLE
feat: Adds support for associated document fields in builder

### DIFF
--- a/src/Builder/DE/BuilderInterface.php
+++ b/src/Builder/DE/BuilderInterface.php
@@ -103,4 +103,8 @@ interface BuilderInterface
      * Grupo F Campos que describen los subtotales y totales de la transacción documentada.
      */
     public function setGroupF($data);
+    /**
+     * Grupo H. Campos que identifican al documento asociado.
+     */
+    public function setGroupH($data);
 }

--- a/src/Builder/DE/Concrete/FacturaElectronicaBuilder.php
+++ b/src/Builder/DE/Concrete/FacturaElectronicaBuilder.php
@@ -17,6 +17,8 @@ use Nyxcode\PhpSifenTool\Enums\TipoOperacion;
 use Nyxcode\PhpSifenTool\Enums\TipoPago;
 use Nyxcode\PhpSifenTool\Enums\TipoTransaccion;
 use Nyxcode\PhpSifenTool\Enums\Tag\DE;
+use Nyxcode\PhpSifenTool\Enums\TipoConstancia;
+use Nyxcode\PhpSifenTool\Enums\TipoDocumentoAsociado;
 use PHPUnit\Event\Runtime\PHP;
 
 class FacturaElectronicaBuilder implements BuilderInterface
@@ -38,6 +40,7 @@ class FacturaElectronicaBuilder implements BuilderInterface
     protected TagComposite $gCamItem;
     protected TagComposite $gValorItem;
     protected TagComposite $gTotSub;
+    protected TagComposite $gCamDEAsoc;
     protected TagLeaf $iTiDE;
     protected TagLeaf $dDesTiDE;
 
@@ -951,6 +954,74 @@ class FacturaElectronicaBuilder implements BuilderInterface
         $this->gTotSub->add($dTotalGs);
 
         $this->de->add($this->gTotSub);
+    }
+
+    public function setGroupH($data)
+    {
+        if (in_array($this->iTiDE->getValue(), [
+            TipoDocumentoElectronico::FEE->value,
+            TipoDocumentoElectronico::FEI->value,
+            TipoDocumentoElectronico::CRE->value,
+        ])) {
+            return;
+        }
+
+        if (empty($data['iTipDocAso'])) {
+            return;
+        }
+
+        $this->gCamDEAsoc = new TagComposite(DE::G_CAM_DE_ASOC);
+
+        $iTipDocAso = new TagLeaf(DE::I_TIP_DOC_ASO, $data['iTipDocAso']);
+        $this->gCamDEAsoc->add($iTipDocAso);
+
+        $dDesTipDocAso = new TagLeaf(DE::D_DES_TIP_DOC_ASO, $data['dDesTipDocAso']);
+        $this->gCamDEAsoc->add($dDesTipDocAso);
+
+        if ($iTipDocAso->getValue() === TipoDocumentoAsociado::ELECTRONICO->value) {
+            $dCdCDERef = new TagLeaf(DE::D_CDC_DE_REF, $data['dCdCDERef']);
+            $this->gCamDEAsoc->add($dCdCDERef);
+        }
+
+        if ($iTipDocAso->getValue() === TipoDocumentoAsociado::IMPRESO->value) {
+            $dNTimDI = new TagLeaf(DE::D_N_TIM_DI, $data['dNTimDI']);
+            $this->gCamDEAsoc->add($dNTimDI);
+
+            $dEstDocAso = new TagLeaf(DE::D_EST_DOC_ASO, $data['dEstDocAso']);
+            $this->gCamDEAsoc->add($dEstDocAso);
+
+            $dPExpDocAso = new TagLeaf(DE::D_P_EXP_DOC_ASO, $data['dPExpDocAso']);
+            $this->gCamDEAsoc->add($dPExpDocAso);
+
+            $dNumDocAso = new TagLeaf(DE::D_NUM_DOC_ASO, $data['dNumDocAso']);
+            $this->gCamDEAsoc->add($dNumDocAso);
+
+            $iTipoDocAso = new TagLeaf(DE::I_TIP_DOC_ASO, $data['iTipoDocAso']);
+            $this->gCamDEAsoc->add($iTipoDocAso);
+
+            $dDTipoDocAso = new TagLeaf(DE::D_D_TIPO_DOC_ASO, $data['dDTipoDocAso']);
+            $this->gCamDEAsoc->add($dDTipoDocAso);
+
+            $dFecEmiDI = new TagLeaf(DE::D_FEC_EMI_DI, $data['dFecEmiDI']);
+            $this->gCamDEAsoc->add($dFecEmiDI);
+        }
+
+        if ($iTipDocAso->getValue() === TipoDocumentoAsociado::CONSTANCIA_ELECTRONICA->value) {
+            $iTipCons = new TagLeaf(DE::I_TIP_CONS, $data['iTipCons']);
+            $this->gCamDEAsoc->add($iTipCons);
+
+            $dDesTipCons = new TagLeaf(DE::D_DES_TIP_CONS, $data['dDesTipCons']);
+            $this->gCamDEAsoc->add($dDesTipCons);
+
+            if ($iTipCons->getValue() === TipoConstancia::CONSTANCIA_MICROPRODUCTORES->value) {
+                $dNumCons = new TagLeaf(DE::D_NUM_CONS, $data['dNumCons']);
+                $this->gCamDEAsoc->add($dNumCons);
+
+                $dNumControl = new TagLeaf(DE::D_NUM_CONTROL, $data['dNumControl']);
+                $this->gCamDEAsoc->add($dNumControl);
+            }
+        }
+        $this->de->add($this->gCamDEAsoc);
     }
 
     public function getResult()

--- a/src/Builder/DE/Director.php
+++ b/src/Builder/DE/Director.php
@@ -42,5 +42,6 @@ class Director
         $this->builder->setGroupD3($data);
         $this->builder->setGroupE($data);
         $this->builder->setGroupF($data);
+        $this->builder->setGroupH($data);
     }
 }

--- a/src/Enums/TipoConstancia.php
+++ b/src/Enums/TipoConstancia.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Nyxcode\PhpSifenTool\Enums;
+
+enum TipoConstancia: int
+{
+    case CONSTANCIA_NO_SER_CONTRIBUYENTE = 1;
+    case CONSTANCIA_MICROPRODUCTORES = 2;
+
+    public function getDescripcion(): string
+    {
+        return match ($this) {
+            self::CONSTANCIA_NO_SER_CONTRIBUYENTE => 'Constancia de no ser contribuyente',
+            self::CONSTANCIA_MICROPRODUCTORES => 'Constancia de microproductores',
+        };
+    }
+}

--- a/src/Enums/TipoDocumentoAsociado.php
+++ b/src/Enums/TipoDocumentoAsociado.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Nyxcode\PhpSifenTool\Enums;
+
+enum TipoDocumentoAsociado: int
+{
+    case ELECTRONICO = 1;
+    case IMPRESO = 2;
+    case CONSTANCIA_ELECTRONICA = 3;
+
+    public function getDescripcion(): string
+    {
+        return match ($this) {
+            self::ELECTRONICO => 'Electrónico',
+            self::IMPRESO => 'Impreso',
+            self::CONSTANCIA_ELECTRONICA => 'Constancia Electrónica',
+        };
+    }
+}

--- a/src/Enums/TipoDocumentoImpreso.php
+++ b/src/Enums/TipoDocumentoImpreso.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Nyxcode\PhpSifenTool\Enums;
+
+enum TipoDocumentoImpreso: int
+{
+    case FACTURA = 1;
+    case NOTA_CREDITO = 2;
+    case NOTA_DEBITO = 3;
+    case NOTA_REMISION = 4;
+    case COMPROBANTE_RETENCION = 5;
+
+    public function getDescripcion(): string
+    {
+        return match ($this) {
+            self::FACTURA => 'Factura',
+            self::NOTA_CREDITO => 'Nota de crédito',
+            self::NOTA_DEBITO => 'Nota de débito',
+            self::NOTA_REMISION => 'Nota de remisión',
+            self::COMPROBANTE_RETENCION => 'Comprobante de retención',
+        };
+    }
+}

--- a/tests/Feature/FEBuilderTest.php
+++ b/tests/Feature/FEBuilderTest.php
@@ -17,6 +17,7 @@ use Nyxcode\PhpSifenTool\Enums\TipoCambioOperacion;
 use Nyxcode\PhpSifenTool\Enums\TipoCondicionAnticipo;
 use Nyxcode\PhpSifenTool\Enums\TipoCondicionOperacion;
 use Nyxcode\PhpSifenTool\Enums\TipoContribuyente;
+use Nyxcode\PhpSifenTool\Enums\TipoDocumentoAsociado;
 use Nyxcode\PhpSifenTool\Enums\TipoDocumentoReceptor;
 use Nyxcode\PhpSifenTool\Enums\TipoEmision;
 use Nyxcode\PhpSifenTool\Enums\TipoImpuesto;
@@ -211,7 +212,10 @@ class FEBuilderTest extends TestCase
                         "dBasGravIVA" => 9090,
                         "dLiqIVAItem" => 9090,
                     ],
-                ]
+                ],
+                "iTipDocAso" => TipoDocumentoAsociado::ELECTRONICO->value,
+                "dDesTipDocAso" => TipoDocumentoAsociado::ELECTRONICO->getDescripcion(),
+                "dCdCDERef" => '01800782585001001000067622025011314272500570',
             ]]
         ];
     }


### PR DESCRIPTION
Implements the `setGroupH` method to handle fields related to associated documents.

Enhances the builder to accommodate different types of associated documents, including electronic and printed types, with specific fields based on their type.

Updates the interface to include the new method and modifies the director to invoke it during the building process.

PST-1, PST-7